### PR TITLE
support for "chromium" and "chromium-browser"

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 : ${1?"Usage: USERNAME Needed"}
 nohup python3.8 main.py --user $1 > /dev/null &
-chromium-browser --app="http://0.0.0.0:8099/__display__.html" > /dev/null &
+{
+    chromium-browser --app="http://0.0.0.0:8099/__display__.html" > /dev/null &
+} && {
+    chromium --app="http://0.0.0.0:8099/__display__.html" > /dev/null &
+}


### PR DESCRIPTION
This adds some support for both browsers named "chromium-browser" and "chromium." This will throw an error if you don't have chromium-browser and have chromium, or vise-versa, but it runs for both namings. When I tried to run this originally, I wasn't able to, as my chromium-browser was named as "chromium." This probably isn't the best implementation of this, but it works